### PR TITLE
Expose a configuration file for loading rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Collection of miscellaneous TSLint rules
     "sort-imports": true
   },
   "rulesDirectory": [
-    "./node_modules/tslint-misc-rules/rules"
+    "tslint-misc-rules"
   ]
 }
 ```
@@ -38,7 +38,7 @@ Collection of miscellaneous TSLint rules
 1. [no-braces-for-single-line-arrow-functions](#13) [has autofix]
 1. [no-unnecessary-parens-for-arrow-function-arguments](#14)
 
-## <a name="1"></a>"sort-imports" [↑](#TOC) 
+## <a name="1"></a>"sort-imports" [↑](#TOC)
 Fails:
 ```ts
 import b from "b";

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tslint-misc-rules",
   "version": "3.3.3",
   "description": "Collection of miscellaneous TSLint rules",
-  "main": "index.js",
+  "main": "rules/index.json",
   "scripts": {
     "build": "tsc --inlineSourceMap",
     "ci": "yarn build && yarn test",

--- a/rules/index.json
+++ b/rules/index.json
@@ -1,0 +1,3 @@
+{
+	"rulesDirectory": "."
+}


### PR DESCRIPTION
We bundle our TSLint config into an external, shareable package, and this makes using relative paths impossible:

```
Failed to load <...>/tslint.yml: Could not find custom rule directory: ./node_modules/tslint-misc-rules/rules
```

This is because, in the case of a shareable configuration, `tslint-misc-rules` exists as a dependency of the main project while `./node_modules/tslint-misc-rules/` is relative to the shareable configuration package.
The cleanest way to solve this that we found is to expose the rules. I took example from [`tslint-microsoft-contrib`](https://github.com/Microsoft/tslint-microsoft-contrib/blob/master/tslint.json#L2-L4) and [`tslint-consistent-codestyle`](https://github.com/ajafff/tslint-consistent-codestyle/blob/master/rules/index.ts#L3).

Plus it makes for a nicer README :)